### PR TITLE
RNP-000 Modifications

### DIFF
--- a/RNP-000.md
+++ b/RNP-000.md
@@ -4,259 +4,87 @@
 |000   |Proposal Genesis |Process |Render Network Team|06-06-2022| Implemented |
 ---
 
-# What is an RNP?
-Welcome to the first official RNP proposal!
+# Render Network Governance and Proposal Genesis
 
-RNP stands for **Render Network Proposal** and will be the format that the
-community can use to give input and feedback on the direction of the Render
-Network. This RNP (#000) will serve as a template explainer, a reference for
-users on the full RNP format.
+The Render Network is a decentralized GPU computing platform that enables creators to harness the power of a distributed compute protocol. As the network grows and evolves, it is crucial to maintain a robust governance framework that allows all stakeholders to collaborate effectively in steering the future direction of the protocol.
 
-Each RNP will consist of the following structure:
+The purpose of this Render Network Proposal (RNP) is to formally elevate and codify the governance process for the Render Network. RNPs serve as the primary mechanism through which the Render Network community can propose, debate, and implement changes and improvements to the protocol.
 
- 1. *Title and RNP-###*
- 2. *Author*
- 3. *Overview*
- 4. *Category*
- 5. *Motivation*
- 6. *Stakeholders*
- 7. *Implementation*
- 8. *Technical Considerations*
- 9. *Drawbacks*
+## RNP Structure
 
-Here is an example of how it will all work:
+To ensure clarity and consistency, each RNP shall adhere to the following standardized template:
 
-## Title and RNP-###
-Each RNP will have a title (like the one above) and a three digit RNP number
-that is assigned to it, pending approval and certain processes. 
+1. Title and RNP Number
+2. Author(s)
+3. Overview
+4. Category
+5. Reasoning
+6. Stakeholders Impacted
+7. Implementation Plan
+8. Technical Considerations
+9. Potential Drawbacks
 
-## Author
-This is self-explanatory, but the author(s) of the RNP should list their name(s)
-for accreditation. In the above case, it would be the Render Network Team
+## Scope of Render Network Proposals
 
-## Overview
-Each RNP will also have an Overview section, where it goes into details about
-the proposal. This RNPs Overview section is self-explanatory.
+Render Network Proposals should be reserved for significant initiatives that have a substantial impact on the core functionality, governance, or strategic direction of the Render Network. RNPs should propose changes or improvements that are critical to the network's long-term success and require the attention and consensus of the entire community.
 
-## Category
-Each RNP should have a category. There are two main categories an RNP (Render
-Network Proposal) can fall under: **Core** or **Process**. Core proposals have
-two subcategories: ***Technical*** and ***Ecosystem Fund Allocation***.
+Examples of suitable RNPs include, but are not limited to:
+- Modifications to the network's rendering algorithms or infrastructure
+- Adjustments to the economic model or token mechanics
+- Introduction of new features or services that significantly enhance the value proposition of the network
+- Changes to the governance process itself
 
-### Core: Technical
-Proposals for technical changes to the Render Network requiring development
-review.
-### Core: Ecosystem Fund Allocation
-Proposals for how ecosystem funds should be utilized.
-### Process
-Proposals for making a change to a process or implementation. Examples include
-procedures, guidelines, changes to the decision-making process, and changes to
-the tools or environment of the Network.
+## Render Foundation Grants
 
-## Reasoning
-RNPs will also have a “*reasoning*” section. For example, this RNPs reasoning
-would be:
+For smaller projects, incremental improvements, or initiatives that do not meet the threshold of significance for an RNP, community members are encouraged to explore alternative avenues for support and collaboration.
 
-"*As the Render Network grows, its need to satisfy all stakeholders grows as
-well. Allowing the users of the network to help determine future features and
-products will benefit the project and let the most important and pressing ideas
-come forward.*" 
+The Render Foundation, a separate entity dedicated to fostering the growth of the Render ecosystem, offers grants and resources for projects that contribute to the network's development and adoption. Community members with ideas for smaller-scale projects or targeted enhancements should consider applying for a Render Foundation Grant.
 
-## Stakeholders
-There are various stakeholders that can be referenced within the RNPs. Here is a
-list of all of them:
+Information on the grant application process, eligibility criteria, and funding guidelines can be found on the [Render Foundation website](renderfoundation.com/grants). The Render Foundation Team and community moderators are available to provide guidance and assistance to help direct prospective applicants to the appropriate channel.
 
-### Creators:
-Creators are digital artists, developers and studios who utilize the Render
-Network to render their digital creations on the blockchain for a fraction of
-the speed and cost of standard in-house rendering or computation.
-### Consumers
-Consumers constitute a more passive group of creative participants of the Render
-Network, such as NFT collectors, gamers and fandom communities, who compose and
-interact with core digital assets, IP and services offered by Creators on the
-Render Network. NFT’s minted on Render may also enable creators to offer
-consumers voting power and agency on governance for their specific services and
-content they offer through the Render Network.
-### Node Operators
-Node Operators are GPU owners who have registered their machines on the Render
-Network to be used by Creators in order to render their work when not in use, in
-exchange for RNDR Tokens.
-### Liquidity Providers
-Liquidity Providers are RNDR Token holders who hold RNDR on applicable
-centralized and decentralized exchanges.
-### Render Network Team
-The Render Network Team are the builders and maintainers of the Render Network.
-This group includes the Render Network’s team of developers and blockchain
-engineers, and various other team members who provide services to the Render
-Network and run the everyday operations of the platform.
-### Render Network Partners
-Render Network is partnered with many groups and individuals in order to improve
-the capabilities of the platform. This includes companies like Multicoin,
-Alameda Research, NVIDIA, Google, Apple and Microsoft, as well as individuals
-and key advisory board members such as digital artist Beeple, Ari Emanuel
-(founder & CEO of Endeavor/WME/IMG) and fellow blockchain projects like Solana
-and Algorand.
+By differentiating between significant RNPs and smaller-scale projects suitable for Render Foundation Grants, the community can ensure that the RNP process remains focused on critical governance decisions while still providing support and opportunities for a wide range of initiatives that benefit the Render ecosystem.
 
-## Implementation
-The Render Network maintains a number of community chats across multiple
-platforms, including Telegram, Twitter, Discord, the Render Network website and
-Instagram. Currently a majority of news from the Render Network team is directly
-communicated through the Render Network Medium blog, and shared across social
-media channels like Telegram, Twitter and Instagram.
+## RNP Lifecycle
 
-Because it is the most commonly used communication channel in Web3, discussions
-will be shifting over to Discord as it provides the most appropriate tools to
-facilitate and manage discussion on each RNP. The discussions may be augmented
-with RNP forums on the Render Network website as the number of RNPs grows over
-time.
+RNPs shall progress through the following phases from conception to implementation:
 
-### Proposal Process
-RNPs are the process by which the community can affect change on the Render
-Network. Outlined below are all of the steps through which a community member
-can go from idea to implementation onto the Render Network. The steps an RNP
-needs to take are as follows:
+### Initial Draft
 
- 1. **Initial Proposal or Grant**
- 2. **Draft Submission**
- 3. **Initial Proposal Vote**
- 4. **Render Network Team Review**
- 5. **RNP Vote**
- 6. **Implementation**
+The proposer shall engage in preliminary discussions with the Render Network community to refine the idea and draft an RNP adhering to the standardized template. An RNP can either be submitted to the Render Network Foundation team for dissemination or a Pull Request can be made to the RNP repository. A dedicated channel within the Render Network Discord server shall be created to facilitate community discussion and feedback on the draft proposal.
 
-#### Initial Proposal or Grant
-Members should reach out to an admin or moderator on the Render Network Team to
-discuss an improvement to the protocol. The Team will help direct if this is a
-good candidate for an RNP or a Grant. Grant information can be found on the
-Render Foundation Website. If it is a good candidate for an RNP the admin or
-moderator will label it as an “Initial Proposal” and create a dedicated channel
-in the [Render Network Discord](https://discord.gg/rendernetwork). Proposals
-must conform to the Render Network guidelines and use the RNP Template before
-approval by an admin or moderator. 
+RNP proposers should communicate with the Render Foundation to ensure the given proposal falls under the mandate of Render Network protocol improvements. The team will then direct if the given proposal is a candidate for an RNP or a Grant. If a proposal is directly submitted to the repository and falls under Grant mandates, the Render Foundation may reject an RNP proposal. Grant information can be found on the Render Foundation Website.
 
-#### Draft Submission
-The Initial Proposal will then be discussed by the community within its Discord
-Channel.
+### Initial Proposal Vote
 
-During this stage, the author may adjust the Initial Proposal based on feedback
-received, provided such changes are tracked. 
+The draft RNP shall be put forth for a simple majority vote to gauge community interest and support. This vote shall remain open for a period of 72 hours and shall not be subject to any quorum requirement. Should the proposal garner majority support, it shall proceed to the Final RNP Vote phase.
 
-At any time after creation of the Discord Channel, the author may either notify
-an admin via the Discord Channel that they will be withdrawing the proposal, or
-can request it be put through to a “Initial Proposal Vote”, at which point the
-Discord channel will be closed and will no longer accept new comments. 
+### Final RNP Vote
 
-#### Initial Proposal Vote
-Each week on Monday at 12pm PT, the Initial Proposals that are available for
-vote will be released via an announcement on the Render Network Telegram,
-Discord and Twitter accounts. The actual voting period will last 72 hours and
-conclude on the respective day at 12pm PT. The vote will be a simple majority
-vote and will have no restrictions on total votes, supply, etc. 
+The refined RNP shall be presented to the community for a decisive vote conducted through the voting platform (as of writing, [Snapshot](snapshot.org) and [NATION](nation.io)). The voting period shall span 6 days. For an RNP to be considered approved, it must satisfy the following criteria:
+- Attain a majority approval of at least 50% of the total votes cast
+- Achieve a quorum of at least 15% of the total combined RNDR and RENDER token supply participating in the vote
+- Snapshots of RENDER SPL and RNDR ERC tokens will typically be captured within 24-hours of a vote going live.
 
-All RNDR holders will have access to voting mechanisms on proposed changes. To
-participate in the Snapshot vote, users must go through a wallet verification
-process to confirm RNDR (either Layer 1 or Layer 2) was present in their wallet
-at the time the Snapshot vote was opened.  It is not possible to use RNDR held
-within a liquidity position on an exchange to vote. If successful, an RNP will
-be created in GitHub and marked as *“In Render Team Review”*.
+### Implementation
 
-#### Render Network Team Review
-The RNP will then be reviewed and commented on by the Render Network team (made
-up of core members of the Render Network engineering team, community moderators
-and infrastructure developers) to make sure that it is economically and
-efficiently feasible, project costs and review any additional issues or topics
-that may pose a block to the RNP. After initial discussions, which will last up
-to 21 days, an internal vote will be taken regarding whether the RNP is ready to
-proceed to *“Open for RNP Vote”* status. This review process is critical to the
-RNP implementation in two ways:
+Upon approval, RNPs shall be incorporated into the Render Network's development roadmap and implemented by core Render Network contributors. The status and progress of each RNP shall be transparently tracked and communicated via the Render Foundation Team and in the designated GitHub repository.
 
-	1. It seeks to add more color to the initial RNP in order to give the
-	community more information for voting purposes. 2. It puts some
-	responsibility in the hands of the actual implementation team to perform due
-	diligence on the RNP process.
-	
-The review and the comments will be made public by the team on the Discord, so
-that the community can understand the team’s thought process and reasoning.
 
-If the RNP is approved (has been deemed technically feasible without significant
-roadblocks to development, as listed above), it moves onto the next step and its
-status is updated to *"Open for RNP Vote”*. If the RNP is not approved, it can
-be edited and resubmitted as a new *Initial Proposal*, so long as the proposal
-has not been deemed intangible or illegitimate by the Render Network team and
-moderators.
-
-#### RNP Vote
-Snapshot voting for *Open for RNP Vote* RNPs will be subject to a vote every
-week commencing at 5pm PT on Wednesday. Voting will be open for 6 days, until
-5pm PT on the following Tuesday. 
-
-RNP approval will be judged on a majority of 50% of total “Approve” or “Deny”
-votes cast ratio AND a minimum of 25% of total supply being cast to vote. Any
-wallet can abstain from the vote and not count for the for or against but count
-to the total votes cast. For example, if the vote was 80% approve, but only
-10,000 tokens were cast for the vote, the RNP would not pass. It would pass if
-it was the same scenario with 25% of the total supply participating by
-abstaining in addition to the 10,000 tokens that voted “Approve” or “Deny”. 
-
-#### Implementation
-If an RNP is able to garner community approval, its status will be updated to
-*“Approved and on the Roadmap”*, and it will then be added to the Roadmap. The
-network will continue to use GitHub as the basis for communication of
-implementation status on such approved RNPs providing notice when they move into
-development by updating their status to *“In Development”*, and finally
-*“Implemented”*, with the communication coming from Discord. The Render Network
-Team will be in charge of implementing said changes to the Network. Though RNP
-changes may not be implemented immediately, all approved RNPs will eventually be
-implemented.
-	
-#### Emergency Proposal and Voting Protocol
-This proposal timeline and voting threshold can be adjusted in the case of an
-*"Emergency Proposal and Voting"* scenario. In cases where a proposal has been
-deemed an emergency, for example if action needs to be taken to ensure
-uninterrupted operation of the Network, timelines can be adjusted in order to
-more urgently implement a community approved proposal. For an emergency
-proposal, the Draft submission and Initial Proposal Vote can be forgone provided
-that in such instances, the threshold for RNP approval would be increased to 33%
-of total supply.
-
-** *All RNP statuses can be viewed within Github, where they will be classified
+All RNP statuses can be viewed within Github, where they will be classified
 as "In Render Team Review", "Open for RNP Vote", "Rejected", "Approved and on
-the Roadmap", “In Development” and “Implemented”.* **
+the Roadmap", “In Development” and “Implemented”.
 
-## Technical Considerations
-The Render Network team will be required to moderate, review, as well as track
-and document the RNP process in Github.
+## Emergency Proposal Provision
 
-## Drawbacks
-There will be a transition and learning curve from the community with regard to
-getting users on the Discord, however, given that Discord is the communication
-choice for most modern crypto projects, this should not pose a large issue.
-There will also likely need to be adjustments to the RNP process as new
-proposals come in, but the team will act swiftly to make sure that the process
-is seamless.
+In the event of an emergency situation necessitating swift action to ensure the uninterrupted operation of the Render Network, the Initial Proposal Vote phase may be omitted, and the quorum requirement for the Final RNP Vote shall be elevated to 20% of the total Render token supply.
 
-## Guidelines for RNPs
+## Amendments
+RNPs can undergo updates to enhance clarity or incorporate new information for improved accuracy. These revisions aim to maintain the original intent of the proposal. Amendments may include adjustments such as correcting typographical errors, updating technical details, or reflecting changes like a Compute Client's name alteration. Large amendments will be submitted to vote for a shortened period of two days if deemed necessary by the Render Foundation team.
 
- 1. Members should research previous proposals to ensure that their RNP has not
-    already been submitted or does not conflict with a proposal up for vote.
- 2. RNPs that conflict with a proposal that is currently up for vote, will only
-    be put up for vote after a significant time has elapsed from when the first
-    proposal was voted on in order to avoid conflicts and wasted effort.
- 3. RNPs will be removed from consideration if they involve illegal activity,
-    hate speech, pornographic material, or do not represent the mission or
-    values of the Render Network.
- 4. Technically infeasible RNPs will be removed from consideration during the
-    review period - i.e. a component of the review process is assessing whether
-    RNPs are actionable.
+## RNP Content Guidelines
 
-## Community Principles
-* *Equality*: It is important that everyone feels like they have a voice no
-  matter their background and however small or large they are. The network is
-  working to bring high end 3D graphics and related digital experiences to
-  anyone with a creative vision.
-* *Constructiveness*: The network is more than the sum of its parts, and looks
-  for positive contributions to building the future of decentralized GPU
-  computing.
-* *Transparency*: Decisions will be publicly communicated openly and
-  communication channels will provide open, publicly accessible forums to debate
-  the future of RNPs.
+To maintain the integrity and effectiveness of the RNP process, members should research previously submitted proposals to avoid duplication or conflicts. RNPs that overlap with an active proposal will be deferred until a significant time has elapsed after the original proposal's vote concludes. The Render Foundation reserves the right to remove RNPs from consideration if they involve illegal activity, hate speech, pornographic material, discriminatory content, copyrighted material without permission, or other content that violates the mission, values, or Code of Conduct of the Render Network.
 
+## Conclusion
+
+By establishing this transparent, inclusive, and collaborative RNP process, the Render Network will exemplify decentralized governance and harness the collective wisdom of its diverse community to drive ongoing innovation and improvement of the protocol. As the community gains experience with decentralized decision-making, the RNP process itself may evolve to better serve the needs of the network and its stakeholders as well.


### PR DESCRIPTION
This pull request proposes several amendments to the existing RNP-000, which outlines the governance process for the Render Network. The key changes include:

* Simplified and streamlined the RNP structure by consolidating sections and removing redundant information
* Clarified the distinction between RNPs and Render Foundation Grants, providing guidance on when to pursue each avenue
* Refined the RNP lifecycle:
    * Removed the "Render Network Team Review" phase to empower the community and reduce centralized decision-making
* Updated the quorum requirement for the Final RNP Vote to 15% of the total combined RNDR and RENDER token supply
* Introduced an amendment process for making minor updates to RNPs, such as correcting typographical errors or updating technical details
* Streamlined the emergency proposal provision and increased the quorum requirement to 20% for emergency votes
* Condensed the "Guidelines for RNPs" and "Community Principles" sections into a more concise "RNP Content Guidelines" section

These amendments refine and optimize the RNP process based on community response. These changes seek to enhance the efficiency and effectiveness of Render Network's decentralized governance.